### PR TITLE
Dirty: Pull audio.primary.mt6589.so from CM devices as well

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -18,5 +18,6 @@ done
 # some extra stuff
 adb pull /system/lib/hw/audio_policy.default.so $BASE/lib/hw/audio_policy.mt6589.so
 adb pull /system/lib/libaudio.primary.default.so $BASE/lib/hw/audio.primary.mt6589.so
+adb pull /system/lib/hw/audio.primary.mt6589.so $BASE/lib/hw/audio.primary.mt6589.so
 
 ./setup-makefiles.sh


### PR DESCRIPTION
as paths differ from AOSP / FPOS devices pull audio.primary.mt6589.so from the hw directory and ignore the adb warning
